### PR TITLE
Twig block fix

### DIFF
--- a/Resources/doc/usage_with_schema.md
+++ b/Resources/doc/usage_with_schema.md
@@ -79,7 +79,7 @@ Here is very simple working example, just for some pointers:
 
     {% extends "::base.html.twig" %}
 
-    {% block main %}{# or whatever is your block name #}
+    {% block body %}{# or whatever is your block name #}
     <form method="POST" action="{{ path('padam87_attribute_schema_edit', { id: schema.getId() }) }}">
         {{ form_rest(form) }}
 


### PR DESCRIPTION
Make demo work in a default situation. Main block is not in use by parent.
