### PR TITLE
simplify boolean logic

### DIFF
--- a/Form/EventListener/AttributeSubscriber.php
+++ b/Form/EventListener/AttributeSubscriber.php
@@ -108,11 +108,7 @@ class AttributeSubscriber implements EventSubscriberInterface
             $value = null;
         }
 
-        if ($definition->getRequired() == true) {
-            $params['required'] = true;
-        } else {
-            $params['required'] = false;
-        }
+        $params['required'] = $definition->getRequired();
 
         $params['label'] = $definition->getName();
 


### PR DESCRIPTION
If required is true, then the other required should be true too, otherwise it
should be false.