### PR TITLE
Ensure an attribute always has a definition

### DIFF
--- a/Entity/Attribute.php
+++ b/Entity/Attribute.php
@@ -30,7 +30,7 @@ class Attribute
      * @var Definition
      *
      * @ORM\ManyToOne(targetEntity="Definition", inversedBy="attributes")
-     * @ORM\JoinColumn(name="definition_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="definition_id", referencedColumnName="id", nullable=false)
      */
     private $definition;
 


### PR DESCRIPTION
I noticed empty attributes in my database, I don't know where they come from, but I can't see why this should be allowed.